### PR TITLE
Refactor use cases

### DIFF
--- a/src/git_portfolio/config_manager.py
+++ b/src/git_portfolio/config_manager.py
@@ -1,24 +1,10 @@
 """Configuration manager module."""
 import os
 import pathlib
-from typing import List
 
 import yaml
 
-
-class Config:
-    """Config class."""
-
-    def __init__(
-        self,
-        github_hostname: str,
-        github_access_token: str,
-        github_selected_repos: List[str],
-    ):
-        """Constructor."""
-        self.github_hostname = github_hostname
-        self.github_access_token = github_access_token
-        self.github_selected_repos = github_selected_repos
+import git_portfolio.domain.config as c
 
 
 class ConfigManager:
@@ -36,13 +22,13 @@ class ConfigManager:
                     data = yaml.safe_load(config_file)
                     if data:
                         try:
-                            self.config = Config(**data)
+                            self.config = c.Config(**data)
                             return
                         except TypeError:
                             config_file.truncate(0)
                 except yaml.scanner.ScannerError:
                     config_file.truncate(0)
-        self.config = Config("", "", [])
+        self.config = c.Config("", "", [])
 
     def config_is_empty(self) -> bool:
         """Check if config is empty."""

--- a/src/git_portfolio/domain/config.py
+++ b/src/git_portfolio/domain/config.py
@@ -1,0 +1,17 @@
+"""Config model."""
+from typing import List
+
+
+class Config:
+    """Config class."""
+
+    def __init__(
+        self,
+        github_hostname: str,
+        github_access_token: str,
+        github_selected_repos: List[str],
+    ):
+        """Constructor."""
+        self.github_hostname = github_hostname
+        self.github_access_token = github_access_token
+        self.github_selected_repos = github_selected_repos

--- a/src/git_portfolio/github_manager.py
+++ b/src/git_portfolio/github_manager.py
@@ -3,16 +3,14 @@ import logging
 import sys
 from typing import Any
 from typing import List
-from typing import Optional
 from typing import Union
 
 import github
-import inquirer
 import requests
 
-import git_portfolio.config_manager as cm
-import git_portfolio.prompt_validation as val
-from git_portfolio.domain.gh_connection_settings import GhConnectionSettings
+import git_portfolio.domain.config as c
+import git_portfolio.prompt as p
+
 
 # starting log
 FORMAT = "%(asctime)s %(message)s"
@@ -21,66 +19,14 @@ logging.basicConfig(level=logging.ERROR, format=FORMAT, datefmt=DATE_FORMAT)
 LOGGER = logging.getLogger(__name__)
 
 
-def prompt_connect_github(github_access_token: str) -> GhConnectionSettings:
-    """Prompt questions to connect to Github."""
-    questions = [
-        inquirer.Password(
-            "github_access_token",
-            message="GitHub access token",
-            validate=val.not_empty_validation,
-            default=github_access_token,
-        ),
-        inquirer.Text(
-            "github_hostname",
-            message="GitHub hostname (change ONLY if you use GitHub Enterprise)",
-        ),
-    ]
-    answers = inquirer.prompt(questions)
-    return GhConnectionSettings(
-        answers["github_access_token"], answers["github_hostname"]
-    )
-
-
-def prompt_new_repos(github_selected_repos: List[str]) -> Any:
-    """Prompt question to know if you want to select new repositories."""
-    message = "\nThe configured repos will be used:\n"
-    for repo in github_selected_repos:
-        message += f" * {repo}\n"
-    print(message)
-    answer = inquirer.prompt(
-        [inquirer.Confirm("", message="Do you want to select new repositories?")]
-    )[""]
-    return answer
-
-
-def prompt_select_repos(repo_names: List[str]) -> Any:
-    """Prompt questions to select new repositories."""
-    while True:
-        selected = inquirer.prompt(
-            [
-                inquirer.Checkbox(
-                    "github_repos",
-                    message="Which repos are you working on? (Select pressing space)",
-                    choices=repo_names,
-                )
-            ]
-        )["github_repos"]
-        if selected:
-            return selected
-        else:
-            print("Please select with `space` at least one repo.\n")
-
-
 class GithubManager:
     """Github manager class."""
 
-    def __init__(self, config: cm.Config) -> None:
+    def __init__(self, config: c.Config) -> None:
         """Constructor."""
         self.config = config
         if config.github_access_token:
-            self._github_setup()
-        else:
-            self.config_ini()
+            self._validate_account()
 
     def get_github_connection(self) -> github.Github:
         """Get Github connection."""
@@ -112,6 +58,10 @@ class GithubManager:
                 )
             )
 
+    def get_repo_names(self) -> List[str]:
+        """Get list of repository names."""
+        return [repo.full_name for repo in self.github_repos]
+
     def _get_github_repos(
         self,
         user: Union[
@@ -121,32 +71,8 @@ class GithubManager:
         """Get Github repos from user."""
         return user.get_repos()
 
-    def config_ini(self) -> None:
-        """Initialize app configuration."""
-        # only config if gets a valid connection
-        valid = False
-        while not valid:
-            answers = prompt_connect_github(self.config.github_access_token)
-            self.config.github_access_token = answers.github_access_token.strip()
-            self.config.github_hostname = answers.github_hostname
-            valid = self._github_setup()
-            if not valid:
-                print("Wrong GitHub token/permissions. Please try again.")
-        self.config_repos()
-
-    def config_repos(self) -> Optional[cm.Config]:
-        """Configure repos in use."""
-        if self.config.github_selected_repos:
-            new_repos = prompt_new_repos(self.config.github_selected_repos)
-            if not new_repos:
-                return None
-
-        repo_names = [repo.full_name for repo in self.github_repos]
-        self.config.github_selected_repos = prompt_select_repos(repo_names)
-        return self.config
-
-    def _github_setup(self) -> bool:
-        """Setup Github connection properties."""
+    def _validate_account(self) -> bool:
+        """Validate Github connection properties."""
         self.github_connection = self.get_github_connection()
         user = self.github_connection.get_user()
         self.github_username = self.get_github_username(user)
@@ -154,3 +80,14 @@ class GithubManager:
             return False
         self.github_repos = self._get_github_repos(user)
         return True
+
+    def set_github_account(self) -> None:
+        """Set Github properties."""
+        valid = False
+        while not valid:
+            answers = p.connect_github(self.config.github_access_token)
+            self.config.github_access_token = answers.github_access_token.strip()
+            self.config.github_hostname = answers.github_hostname
+            valid = self._validate_account()
+            if not valid:
+                print("Wrong GitHub token/permissions. Please try again.")

--- a/src/git_portfolio/prompt.py
+++ b/src/git_portfolio/prompt.py
@@ -1,0 +1,221 @@
+"""User prompting module."""
+from typing import Any
+from typing import List
+
+import inquirer
+
+import git_portfolio.domain.gh_connection_settings as gcs
+import git_portfolio.prompt_validation as val
+from git_portfolio.domain.issue import Issue
+from git_portfolio.domain.pull_request import PullRequest
+from git_portfolio.domain.pull_request_merge import PullRequestMerge
+
+
+def connect_github(github_access_token: str) -> gcs.GhConnectionSettings:
+    """Prompt questions to connect to Github."""
+    questions = [
+        inquirer.Password(
+            "github_access_token",
+            message="GitHub access token",
+            validate=val.not_empty_validation,
+            default=github_access_token,
+        ),
+        inquirer.Text(
+            "github_hostname",
+            message="GitHub hostname (change ONLY if you use GitHub Enterprise)",
+        ),
+    ]
+    answers = inquirer.prompt(questions)
+    return gcs.GhConnectionSettings(
+        answers["github_access_token"], answers["github_hostname"]
+    )
+
+
+def new_repos(github_selected_repos: List[str]) -> Any:
+    """Prompt question to know if you want to select new repositories."""
+    message = "\nThe configured repos will be used:\n"
+    for repo in github_selected_repos:
+        message += f" * {repo}\n"
+    print(message)
+    answer = inquirer.prompt(
+        [inquirer.Confirm("", message="Do you want to select new repositories?")]
+    )[""]
+    return answer
+
+
+def select_repos(repo_names: List[str]) -> Any:
+    """Prompt questions to select new repositories."""
+    while True:
+        selected = inquirer.prompt(
+            [
+                inquirer.Checkbox(
+                    "github_repos",
+                    message="Which repos are you working on? (Select pressing space)",
+                    choices=repo_names,
+                )
+            ]
+        )["github_repos"]
+        if selected:
+            return selected
+        else:
+            print("Please select with `space` at least one repo.\n")
+
+
+def create_issues(github_selected_repos: List[str]) -> Issue:
+    """Prompt questions to create issues."""
+    questions = [
+        inquirer.Text(
+            "title", message="Write an issue title", validate=val.not_empty_validation
+        ),
+        inquirer.Text("body", message="Write an issue body [optional]"),
+        inquirer.Text(
+            "labels", message="Write issue labels [optional, separated by comma]"
+        ),
+        inquirer.Confirm(
+            "correct",
+            message=(
+                f"Confirm creation of issue for the project(s) {github_selected_repos}"
+                ". Continue?"
+            ),
+            default=False,
+        ),
+    ]
+    correct = False
+    while not correct:
+        answers = inquirer.prompt(questions)
+        correct = answers["correct"]
+    return Issue(answers["title"], answers["body"], answers["labels"])
+
+
+def create_pull_requests(github_selected_repos: List[str]) -> PullRequest:
+    """Prompt questions to create pull requests."""
+    questions = [
+        inquirer.Text(
+            "base",
+            message="Write base branch name (destination)",
+            default="master",
+            validate=val.not_empty_validation,
+        ),
+        inquirer.Text(
+            "head",
+            message="Write the head branch name (source)",
+            validate=val.not_empty_validation,
+        ),
+        inquirer.Text(
+            "title", message="Write a PR title", validate=val.not_empty_validation
+        ),
+        inquirer.Text("body", message="Write an PR body [optional]"),
+        inquirer.Confirm(
+            "draft", message="Do you want to create a draft PR?", default=False
+        ),
+        inquirer.Text(
+            "labels", message="Write PR labels [optional, separated by comma]"
+        ),
+        inquirer.Confirm(
+            "confirmation",
+            message="Do you want to link pull request to issues by title?",
+            default=False,
+        ),
+        inquirer.Text(
+            "link",
+            message="Write issue title (or part of it)",
+            validate=val.not_empty_validation,
+            ignore=val.ignore_if_not_confirmed,
+        ),
+        inquirer.Confirm(
+            "inherit_labels",
+            message="Do you want to add labels inherited from the issues?",
+            default=True,
+            ignore=val.ignore_if_not_confirmed,
+        ),
+        inquirer.Confirm(
+            "correct",
+            message=(
+                "Confirm creation of pull request(s) for the project(s) "
+                f"{github_selected_repos}. Continue?"
+            ),
+            default=False,
+        ),
+    ]
+    correct = False
+    while not correct:
+        answers = inquirer.prompt(questions)
+        correct = answers["correct"]
+    return PullRequest(
+        answers["title"],
+        answers["body"],
+        answers["labels"],
+        answers["confirmation"],
+        answers["link"],
+        answers["inherit_labels"],
+        answers["head"],
+        answers["base"],
+        answers["draft"],
+    )
+
+
+def delete_branches(github_selected_repos: List[str]) -> Any:
+    """Prompt questions to delete branches."""
+    questions = [
+        inquirer.Text(
+            "branch", message="Write the branch name", validate=val.not_empty_validation
+        ),
+        inquirer.Confirm(
+            "correct",
+            message=(
+                "Confirm deleting of branch(es) for the project(s) "
+                f"{github_selected_repos}. Continue?"
+            ),
+            default=False,
+        ),
+    ]
+    correct = False
+    while not correct:
+        answers = inquirer.prompt(questions)
+        correct = answers["correct"]
+    return answers["branch"]
+
+
+def merge_pull_requests(
+    github_username: str, github_selected_repos: List[str]
+) -> PullRequestMerge:
+    """Prompt questions to merge pull requests."""
+    questions = [
+        inquirer.Text(
+            "base",
+            message="Write base branch name (destination)",
+            default="master",
+            validate=val.not_empty_validation,
+        ),
+        inquirer.Text(
+            "head",
+            message="Write the head branch name (source)",
+            validate=val.not_empty_validation,
+        ),
+        inquirer.Text(
+            "prefix",
+            message="Write base user or organization name from PR head",
+            default=github_username,
+            validate=val.not_empty_validation,
+        ),
+        inquirer.Confirm(
+            "delete_branch",
+            message="Do you want to delete head branch on merge?",
+            default=False,
+        ),
+        inquirer.Confirm(
+            "correct",
+            message=(
+                "Confirm merging of pull request(s) for the project(s) "
+                f"{github_selected_repos}. Continue?"
+            ),
+            default=False,
+        ),
+    ]
+    correct = False
+    while not correct:
+        answers = inquirer.prompt(questions)
+        correct = answers["correct"]
+    return PullRequestMerge(
+        answers["base"], answers["head"], answers["prefix"], answers["delete_branch"]
+    )

--- a/src/git_portfolio/use_cases/config_init_use_case.py
+++ b/src/git_portfolio/use_cases/config_init_use_case.py
@@ -1,0 +1,27 @@
+"""Initialize config use case."""
+from typing import Union
+
+import git_portfolio.config_manager as cm
+import git_portfolio.github_manager as ghm
+import git_portfolio.prompt as p
+import git_portfolio.response_objects as res
+import git_portfolio.use_cases.config_repos_use_case as cr
+
+
+class ConfigInitUseCase:
+    """Gitp config initialization use case."""
+
+    def __init__(
+        self, config_manager: cm.ConfigManager, github_manager: ghm.GithubManager
+    ) -> None:
+        """Initializer."""
+        self.config_manager = config_manager
+        self.github_manager = github_manager
+
+    def execute(self) -> Union[res.ResponseFailure, res.ResponseSuccess]:
+        """Initialize app configuration."""
+        self.github_manager.set_github_account()
+        repo_names = self.github_manager.get_repo_names()
+        selected_repos = p.select_repos(repo_names)
+        cr.ConfigReposUseCase(self.config_manager).execute(selected_repos)
+        return res.ResponseSuccess("gitp successfully configured.")

--- a/src/git_portfolio/use_cases/config_repos_use_case.py
+++ b/src/git_portfolio/use_cases/config_repos_use_case.py
@@ -1,0 +1,22 @@
+"""Config repositories use case."""
+from typing import List
+from typing import Union
+
+import git_portfolio.config_manager as cm
+import git_portfolio.response_objects as res
+
+
+class ConfigReposUseCase:
+    """Gitp config repositories use case."""
+
+    def __init__(self, config_manager: cm.ConfigManager) -> None:
+        """Initializer."""
+        self.config_manager = config_manager
+
+    def execute(
+        self, selected_repos: List[str]
+    ) -> Union[res.ResponseFailure, res.ResponseSuccess]:
+        """Configuration of git repositories."""
+        self.config_manager.config.github_selected_repos = selected_repos
+        self.config_manager.save_config()
+        return res.ResponseSuccess("gitp repositories successfully configured.")

--- a/src/git_portfolio/use_cases/gh_create_issue_use_case.py
+++ b/src/git_portfolio/use_cases/gh_create_issue_use_case.py
@@ -4,37 +4,10 @@ from typing import List
 from typing import Optional
 
 import github
-import inquirer
 
 import git_portfolio.github_manager as ghm
-import git_portfolio.prompt_validation as val
+import git_portfolio.prompt as p
 from git_portfolio.domain.issue import Issue
-
-
-def prompt_create_issues(github_selected_repos: List[str]) -> Issue:
-    """Prompt questions to create issues."""
-    questions = [
-        inquirer.Text(
-            "title", message="Write an issue title", validate=val.not_empty_validation
-        ),
-        inquirer.Text("body", message="Write an issue body [optional]"),
-        inquirer.Text(
-            "labels", message="Write issue labels [optional, separated by comma]"
-        ),
-        inquirer.Confirm(
-            "correct",
-            message=(
-                f"Confirm creation of issue for the project(s) {github_selected_repos}"
-                ". Continue?"
-            ),
-            default=False,
-        ),
-    ]
-    correct = False
-    while not correct:
-        answers = inquirer.prompt(questions)
-        correct = answers["correct"]
-    return Issue(answers["title"], answers["body"], answers["labels"])
 
 
 class GhCreateIssueUseCase:
@@ -47,9 +20,7 @@ class GhCreateIssueUseCase:
     def execute(self, issue: Optional[Issue] = None, github_repo: str = "") -> None:
         """Create issues."""
         if not issue:
-            issue = prompt_create_issues(
-                self.github_manager.config.github_selected_repos
-            )
+            issue = p.create_issues(self.github_manager.config.github_selected_repos)
         labels = (
             [label.strip() for label in issue.labels.split(",")] if issue.labels else []
         )

--- a/src/git_portfolio/use_cases/gh_create_pr_use_case.py
+++ b/src/git_portfolio/use_cases/gh_create_pr_use_case.py
@@ -1,82 +1,13 @@
 """Create pull request on Github use case."""
 from typing import Any
-from typing import List
 from typing import Optional
 from typing import Set
 
 import github
-import inquirer
 
 import git_portfolio.github_manager as ghm
-import git_portfolio.prompt_validation as val
+import git_portfolio.prompt as p
 from git_portfolio.domain.pull_request import PullRequest
-
-
-def prompt_create_pull_requests(github_selected_repos: List[str]) -> PullRequest:
-    """Prompt questions to create pull requests."""
-    questions = [
-        inquirer.Text(
-            "base",
-            message="Write base branch name (destination)",
-            default="master",
-            validate=val.not_empty_validation,
-        ),
-        inquirer.Text(
-            "head",
-            message="Write the head branch name (source)",
-            validate=val.not_empty_validation,
-        ),
-        inquirer.Text(
-            "title", message="Write a PR title", validate=val.not_empty_validation
-        ),
-        inquirer.Text("body", message="Write an PR body [optional]"),
-        inquirer.Confirm(
-            "draft", message="Do you want to create a draft PR?", default=False
-        ),
-        inquirer.Text(
-            "labels", message="Write PR labels [optional, separated by comma]"
-        ),
-        inquirer.Confirm(
-            "confirmation",
-            message="Do you want to link pull request to issues by title?",
-            default=False,
-        ),
-        inquirer.Text(
-            "link",
-            message="Write issue title (or part of it)",
-            validate=val.not_empty_validation,
-            ignore=val.ignore_if_not_confirmed,
-        ),
-        inquirer.Confirm(
-            "inherit_labels",
-            message="Do you want to add labels inherited from the issues?",
-            default=True,
-            ignore=val.ignore_if_not_confirmed,
-        ),
-        inquirer.Confirm(
-            "correct",
-            message=(
-                "Confirm creation of pull request(s) for the project(s) "
-                f"{github_selected_repos}. Continue?"
-            ),
-            default=False,
-        ),
-    ]
-    correct = False
-    while not correct:
-        answers = inquirer.prompt(questions)
-        correct = answers["correct"]
-    return PullRequest(
-        answers["title"],
-        answers["body"],
-        answers["labels"],
-        answers["confirmation"],
-        answers["link"],
-        answers["inherit_labels"],
-        answers["head"],
-        answers["base"],
-        answers["draft"],
-    )
 
 
 class GhCreatePrUseCase:
@@ -89,7 +20,7 @@ class GhCreatePrUseCase:
     def execute(self, pr: Optional[PullRequest] = None, github_repo: str = "") -> None:
         """Create pull requests."""
         if not pr:
-            pr = prompt_create_pull_requests(
+            pr = p.create_pull_requests(
                 self.github_manager.config.github_selected_repos
             )
 

--- a/src/git_portfolio/use_cases/gh_delete_branch_use_case.py
+++ b/src/git_portfolio/use_cases/gh_delete_branch_use_case.py
@@ -1,34 +1,8 @@
 """Delete branch on Github use case."""
-from typing import Any
-from typing import List
-
 import github
-import inquirer
 
 import git_portfolio.github_manager as ghm
-import git_portfolio.prompt_validation as val
-
-
-def prompt_delete_branches(github_selected_repos: List[str]) -> Any:
-    """Prompt questions to delete branches."""
-    questions = [
-        inquirer.Text(
-            "branch", message="Write the branch name", validate=val.not_empty_validation
-        ),
-        inquirer.Confirm(
-            "correct",
-            message=(
-                "Confirm deleting of branch(es) for the project(s) "
-                f"{github_selected_repos}. Continue?"
-            ),
-            default=False,
-        ),
-    ]
-    correct = False
-    while not correct:
-        answers = inquirer.prompt(questions)
-        correct = answers["correct"]
-    return answers["branch"]
+import git_portfolio.prompt as p
 
 
 class GhDeleteBranchUseCase:
@@ -41,9 +15,7 @@ class GhDeleteBranchUseCase:
     def execute(self, branch: str = "", github_repo: str = "") -> None:
         """Delete branches."""
         if not branch:
-            branch = prompt_delete_branches(
-                self.github_manager.config.github_selected_repos
-            )
+            branch = p.delete_branches(self.github_manager.config.github_selected_repos)
 
         if github_repo:
             self._delete_branch_from_repo(github_repo, branch)

--- a/src/git_portfolio/use_cases/gh_merge_pr_use_case.py
+++ b/src/git_portfolio/use_cases/gh_merge_pr_use_case.py
@@ -1,60 +1,13 @@
 """Merge pull request on Github use case."""
 from typing import Any
-from typing import List
 from typing import Optional
 
 import github
-import inquirer
 
 import git_portfolio.github_manager as ghm
-import git_portfolio.prompt_validation as val
+import git_portfolio.prompt as p
 import git_portfolio.use_cases.gh_delete_branch_use_case as dbr
 from git_portfolio.domain.pull_request_merge import PullRequestMerge
-
-
-def prompt_merge_pull_requests(
-    github_username: str, github_selected_repos: List[str]
-) -> PullRequestMerge:
-    """Prompt questions to merge pull requests."""
-    questions = [
-        inquirer.Text(
-            "base",
-            message="Write base branch name (destination)",
-            default="master",
-            validate=val.not_empty_validation,
-        ),
-        inquirer.Text(
-            "head",
-            message="Write the head branch name (source)",
-            validate=val.not_empty_validation,
-        ),
-        inquirer.Text(
-            "prefix",
-            message="Write base user or organization name from PR head",
-            default=github_username,
-            validate=val.not_empty_validation,
-        ),
-        inquirer.Confirm(
-            "delete_branch",
-            message="Do you want to delete head branch on merge?",
-            default=False,
-        ),
-        inquirer.Confirm(
-            "correct",
-            message=(
-                "Confirm merging of pull request(s) for the project(s) "
-                f"{github_selected_repos}. Continue?"
-            ),
-            default=False,
-        ),
-    ]
-    correct = False
-    while not correct:
-        answers = inquirer.prompt(questions)
-        correct = answers["correct"]
-    return PullRequestMerge(
-        answers["base"], answers["head"], answers["prefix"], answers["delete_branch"]
-    )
 
 
 class GhMergePrUseCase:
@@ -69,7 +22,7 @@ class GhMergePrUseCase:
     ) -> None:
         """Merge pull requests."""
         if not pr_merge:
-            pr_merge = prompt_merge_pull_requests(
+            pr_merge = p.merge_pull_requests(
                 self.github_manager.github_username,
                 self.github_manager.config.github_selected_repos,
             )

--- a/tests/domain/test_config.py
+++ b/tests/domain/test_config.py
@@ -1,0 +1,14 @@
+"""Test cases for config model."""
+import git_portfolio.domain.config as c
+
+
+def test_config_model_init() -> None:
+    """Verify model initialization."""
+    github_hostname = "localhost"
+    github_access_token = "mytoken"
+    github_selected_repos = ["staticdev/omg", "staticdev/omg2"]
+    test_config = c.Config(github_hostname, github_access_token, github_selected_repos)
+
+    assert test_config.github_hostname == github_hostname
+    assert test_config.github_access_token == github_access_token
+    assert test_config.github_selected_repos == github_selected_repos

--- a/tests/test_github_manager.py
+++ b/tests/test_github_manager.py
@@ -3,11 +3,3 @@
 # from unittest.mock import patch
 # import git_portfolio.github_manager as ghm
 # from git_portfolio import config_manager as cm
-
-
-def test_config_repos_dont_select() -> None:
-    """It does nothing."""
-    # config = Mock()
-    # github_manager = ghm.GithubManager(config)
-    # github_manager.config_repos(["staticdev/omg"])
-    pass

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,114 @@
+"""Test cases for user prompting module."""
+import pytest
+from pytest_mock import MockerFixture
+
+import git_portfolio.domain.gh_connection_settings as gcs
+import git_portfolio.prompt as p
+from git_portfolio.domain.issue import Issue
+from git_portfolio.domain.pull_request import PullRequest
+from git_portfolio.domain.pull_request_merge import PullRequestMerge
+
+
+@pytest.fixture
+def mock_inquirer_prompt(mocker: MockerFixture) -> MockerFixture:
+    """Fixture for mocking inquirer.prompt."""
+    return mocker.patch("inquirer.prompt")
+
+
+def test_connect_github(mock_inquirer_prompt: MockerFixture) -> None:
+    """It returns connection settings."""
+    mock_inquirer_prompt.return_value = {
+        "github_access_token": "def",
+        "github_hostname": "my.host.com",
+    }
+    expected = gcs.GhConnectionSettings("def", "my.host.com")
+    result = p.connect_github("abc")
+
+    assert result == expected
+
+
+def test_new_repos(mock_inquirer_prompt: MockerFixture) -> None:
+    """It returns False."""
+    mock_inquirer_prompt.return_value = {"": False}
+    result = p.new_repos(["staticdev/omg"])
+
+    assert result is False
+
+
+def test_select_repos(mock_inquirer_prompt: MockerFixture) -> None:
+    """It returns list with repos."""
+    mock_inquirer_prompt.side_effect = [
+        {"github_repos": []},
+        {"github_repos": ["staticdev/omg"]},
+    ]
+    result = p.select_repos(["staticdev/omg"])
+
+    assert result == ["staticdev/omg"]
+
+
+def test_create_issues(mock_inquirer_prompt: MockerFixture) -> None:
+    """It returns issue."""
+    mock_inquirer_prompt.return_value = {
+        "title": "my title",
+        "labels": ["tests"],
+        "body": "my body",
+        "correct": True,
+    }
+    result = p.create_issues(["staticdev/omg"])
+    expected = Issue("my title", "my body", ["tests"])
+
+    assert result == expected
+
+
+def test_create_pull_requests(mock_inquirer_prompt: MockerFixture) -> None:
+    """It returns pull request."""
+    mock_inquirer_prompt.return_value = {
+        "base": "branch",
+        "head": "main",
+        "title": "my title",
+        "body": "my body",
+        "draft": True,
+        "labels": ["tests"],
+        "confirmation": True,
+        "link": "issue title",
+        "inherit_labels": True,
+        "correct": True,
+    }
+    result = p.create_pull_requests(["staticdev/omg"])
+    expected = PullRequest(
+        "my title",
+        "my body",
+        ["tests"],
+        True,
+        "issue title",
+        True,
+        "main",
+        "branch",
+        True,
+    )
+
+    assert result == expected
+
+
+def test_delete_branches(mock_inquirer_prompt: MockerFixture) -> None:
+    """It returns branch name."""
+    mock_inquirer_prompt.return_value = {"branch": "branch name", "correct": True}
+    result = p.delete_branches(["staticdev/omg"])
+    expected = "branch name"
+
+    assert result == expected
+
+
+def test_merge_pull_requests(mock_inquirer_prompt: MockerFixture) -> None:
+    """It returns pull request merge."""
+    mock_inquirer_prompt.return_value = {
+        "base": "branch",
+        "head": "main",
+        "prefix": "org name",
+        "delete_branch": True,
+        "correct": True,
+    }
+    result = p.merge_pull_requests("staticdev", ["staticdev/omg"])
+    expected = PullRequestMerge("branch", "main", "org name", True)
+
+    assert result == expected

--- a/tests/use_cases/test_config_init_use_case.py
+++ b/tests/use_cases/test_config_init_use_case.py
@@ -1,0 +1,47 @@
+"""Test cases for the gitp config initialization use case."""
+import pytest
+from pytest_mock import MockerFixture
+
+import git_portfolio.use_cases.config_init_use_case as ci
+
+
+@pytest.fixture
+def mock_config_manager(mocker: MockerFixture) -> MockerFixture:
+    """Fixture for mocking ConfigManager."""
+    return mocker.patch("git_portfolio.config_manager.ConfigManager", autospec=True)
+
+
+@pytest.fixture
+def mock_github_manager(mocker: MockerFixture) -> MockerFixture:
+    """Fixture for mocking GithubManager."""
+    return mocker.patch("git_portfolio.github_manager.GithubManager", autospec=True)
+
+
+@pytest.fixture
+def mock_prompt_select_repos(mocker: MockerFixture) -> MockerFixture:
+    """Fixture for mocking prompt.select_repos."""
+    return mocker.patch("git_portfolio.prompt.select_repos")
+
+
+@pytest.fixture
+def mock_config_repos_use_case(mocker: MockerFixture) -> MockerFixture:
+    """Fixture for mocking ConfigReposUseCase."""
+    return mocker.patch(
+        "git_portfolio.use_cases.config_repos_use_case.ConfigReposUseCase",
+        autospec=True,
+    )
+
+
+def test_execute(
+    mock_config_manager: MockerFixture,
+    mock_github_manager: MockerFixture,
+    mock_prompt_select_repos: MockerFixture,
+    mock_config_repos_use_case: MockerFixture,
+) -> None:
+    """It returns success."""
+    config_manager = mock_config_manager.return_value
+    github_manager = mock_github_manager.return_value
+    response = ci.ConfigInitUseCase(config_manager, github_manager).execute()
+
+    assert bool(response) is True
+    assert "gitp successfully configured." == response.value

--- a/tests/use_cases/test_config_repos_use_case.py
+++ b/tests/use_cases/test_config_repos_use_case.py
@@ -1,0 +1,23 @@
+"""Test cases for the gitp repositories config use case."""
+import pytest
+from pytest_mock import MockerFixture
+
+import git_portfolio.domain.config as c
+import git_portfolio.use_cases.config_repos_use_case as cr
+
+
+@pytest.fixture
+def mock_config_manager(mocker: MockerFixture) -> MockerFixture:
+    """Fixture for mocking ConfigManager."""
+    mock = mocker.patch("git_portfolio.config_manager.ConfigManager", autospec=True)
+    return mock
+
+
+def test_execute(mock_config_manager: MockerFixture) -> None:
+    """It returns success."""
+    config_manager = mock_config_manager.return_value
+    config_manager.config = c.Config("", "abc", [])
+    response = cr.ConfigReposUseCase(config_manager).execute(["staticdev/omg"])
+
+    assert bool(response) is True
+    assert "gitp repositories successfully configured." == response.value

--- a/tests/use_cases/test_gh_create_issue_use_case.py
+++ b/tests/use_cases/test_gh_create_issue_use_case.py
@@ -1,0 +1,3 @@
+"""Test cases for the Github create issue use case."""
+# import git_portfolio.prompt as p
+# import git_portfolio.use_cases.gh_create_issue_use_case as ghci

--- a/tests/use_cases/test_gh_create_pr_use_case.py
+++ b/tests/use_cases/test_gh_create_pr_use_case.py
@@ -1,0 +1,3 @@
+"""Test cases for the Github create PR use case."""
+# import git_portfolio.prompt as p
+# import git_portfolio.use_cases.gh_create_pr_use_case as ghcp

--- a/tests/use_cases/test_gh_delete_branch_use_case.py
+++ b/tests/use_cases/test_gh_delete_branch_use_case.py
@@ -1,0 +1,3 @@
+"""Test cases for the Github delete branch use case."""
+# import git_portfolio.prompt as p
+# import git_portfolio.use_cases.gh_delete_branch_use_case as ghdb

--- a/tests/use_cases/test_gh_merge_pr_use_case.py
+++ b/tests/use_cases/test_gh_merge_pr_use_case.py
@@ -1,0 +1,3 @@
+"""Test cases for the Github merge PR use case."""
+# import git_portfolio.prompt as p
+# import git_portfolio.use_cases.gh_merge_pr_use_case as ghmp

--- a/tests/use_cases/test_git_use_case.py
+++ b/tests/use_cases/test_git_use_case.py
@@ -1,4 +1,4 @@
-"""Test cases for the git use case module."""
+"""Test cases for the git use case."""
 from typing import Any
 from unittest.mock import Mock
 


### PR DESCRIPTION
- Add config init and config repo use cases
- Refactor config manager to have Config in domain classes
- Remove prompt and inquirer from use cases
- Rename git_command decorator to gitp_config_check

Closes #119 