### PR TITLE
Revert "Ignore CVE-2020-28476 affecting tornado"

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -100,9 +100,7 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    # Ignore CVE-2020-28476 affecting all versions of tornado
-    # https://github.com/tornadoweb/tornado/issues/2981
-    session.run("safety", "check", f"--file={requirements}", "--bare", "--ignore=39462")
+    session.run("safety", "check", f"--file={requirements}", "--bare")
 
 
 @session(python=python_versions)


### PR DESCRIPTION
This reverts commit d01d1b0aaba9a2af10e7727a130c0c22410cad20.

The CVE has been revoked.