### PR TITLE
Configure darglint to allow long docstrings without signatures

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,4 @@ per-file-ignores = tests/*:S101, S105
 rst-roles = class,const,func,meth,mod,ref
 rst-directives = deprecated
 ; darglint
-strictness = short
+strictness = long


### PR DESCRIPTION
Closes #388 