### PR TITLE
Fix error handling merge PRs

### DIFF
--- a/src/git_portfolio/use_cases/gh.py
+++ b/src/git_portfolio/use_cases/gh.py
@@ -1,4 +1,5 @@
 """Base Github use case."""
+import traceback
 from typing import Any
 from typing import Union
 
@@ -28,9 +29,16 @@ class GhUseCase:
         try:
             method_to_call = getattr(self.github_service, method)
             self.output += method_to_call(*args, **kwargs)
-        except AttributeError as ae:
+        except ghs.GithubServiceError as gse:
             self.error = True
-            self.output += str(ae)
+            self.output += str(gse)
+        except Exception:
+            self.error = True
+            self.output += (
+                "An unexpected error occured. Please report at "
+                "https://github.com/staticdev/git-portfolio/issues/new "
+                f"with the following info:\n{traceback.format_exc()}"
+            )
 
     def generate_response(self) -> Union[res.ResponseFailure, res.ResponseSuccess]:
         """Create appropriate response object."""


### PR DESCRIPTION
- Now call_github_service expects new GithubServiceError and if not it handles it as unexpected error with instructions to open an issue.
- Failure on merge PRs now throws GithubServiceError.

Closes #518